### PR TITLE
fix uncaught error

### DIFF
--- a/SlideRunner/gui/annotation.py
+++ b/SlideRunner/gui/annotation.py
@@ -159,7 +159,7 @@ def removeFromPolygon(self, annotation, annoList):
         reply = QtWidgets.QMessageBox.about(self, "Error", 'Polygon difference did not work. Sorry!')
         return
 
-    if isinstance(diffPolygon, Polygon):
+    if isinstance(diffPolygon, Polygon) and not isinstance(diffPolygon.exterior.coords, list):
         diffPolyCoords = diffPolygon.exterior.coords.xy 
 
         unionCoords = np.float32(np.c_[diffPolyCoords[0],diffPolyCoords[1]])


### PR DESCRIPTION
when selecting remove area from existing annotation while the new polygon covers the entire existing annotation, the following uncaught exception occured:

`  File "/usr/local/lib/python3.7/site-packages/SlideRunner-1.31.0-py3.7.egg/SlideRunner/gui/annotation.py", line 163, in removeFromPolygon
    diffPolyCoords = diffPolygon.exterior.coords.xy
 
AttributeError: 'list' object has no attribute 'xy'`

This PR fixes that. 